### PR TITLE
[FIX] check whether IntroText exists instead of help text in Word export

### DIFF
--- a/Classes/Controller/OapBaseController.php
+++ b/Classes/Controller/OapBaseController.php
@@ -2635,7 +2635,7 @@ class OapBaseController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
                     null,
                     $format['QuestionFont']
                 );
-                if (trim($item->getHelpText())) {
+                if (trim($item->getIntroText())) {
                     $this->addHtmlToSection($section, $item->getIntroText());
                 }
 


### PR DESCRIPTION
In Word export, the IntroText is only output if there is a help text.
However, it must be the case that the IntroText is always output if an IntroText is available.