### PR TITLE
[FIX] Adjusts modal handling for form submission - Safari modal problem

### DIFF
--- a/Resources/Private/Frontend/js-source/utils/modal.js
+++ b/Resources/Private/Frontend/js-source/utils/modal.js
@@ -24,7 +24,8 @@
             modalCancel,
             loaderWrapper;
 
-        const show = function (content, submit, cancel, trigger) {
+        const show = function (content, submit, cancel, form, trigger) {
+
             if (!modalWrapper || !loaderWrapper) {
                 return;
             }
@@ -48,11 +49,11 @@
 
             if (modalSubmit) {
                 modalSubmit.addEventListener('click', function () {
-                    trigger.dataset[dataSet.warningAccepted] = 1;
+                    form.dataset[dataSet.warningAccepted] = 1;
                     modal.hide();
 
                     // Submit from whichever button was originally clicked
-                    document.activeElement.click();
+                    trigger.click();
                     loaderWrapper.style.display = 'flex';
 
                 });

--- a/Resources/Private/Frontend/js-source/validator.js
+++ b/Resources/Private/Frontend/js-source/validator.js
@@ -587,7 +587,7 @@
                     let modalSubmit = labels[e.submitter.dataset[dataSet.modalSubmit]];
                     let modalCancel = labels[e.submitter.dataset[dataSet.modalCancel]];
 
-                    OAP.utils.modal.show(modalContent, modalSubmit, modalCancel, activeForm);
+                    OAP.utils.modal.show(modalContent, modalSubmit, modalCancel, activeForm, e.submitter);
                 }
             } else {
                 // no error and no reason for a hint - but to prevent competing actions, show the loading circle
@@ -595,7 +595,6 @@
                     return;
                 }
                 loaderWrapper.style.display = styles.loaderVisible;
-
             }
             document.querySelectorAll(selector.enableDisabledElements).forEach(function (element) {
                 element.disabled = 0;


### PR DESCRIPTION
Refactors the modal component to correctly handle form submissions. The change ensures that the originally clicked button triggers the form submission after the modal confirmation. This prevents issues where the wrong element was being clicked, leading to unexpected behavior. The active form is passed as an argument to the modal.show function. Fix for Safari problem