### PR TITLE
Uses dynamic asset path for icons

### DIFF
--- a/Resources/Private/Frontend/js-source/init.js
+++ b/Resources/Private/Frontend/js-source/init.js
@@ -1,0 +1,10 @@
+(function (window, OAP) {
+
+    'use strict';
+
+    let document = window.document;
+    let oapDiv = document.querySelector('[data-oap-asset-path]');
+
+    OAP.assetPath = oapDiv.dataset.oapAssetPath || '';
+
+}(this, this.OAP || {}));

--- a/Resources/Private/Frontend/js-source/upload.js
+++ b/Resources/Private/Frontend/js-source/upload.js
@@ -5,6 +5,7 @@
 
     const document = window.document;
     const labels = OAP.labels || {};
+    const pathIconSvg = OAP.assetPath + 'Icons/sprite.svg';
     const ajaxUrl = {
         base: '/index.php?',
         taskInfo: 'oap-ajax-task=info',
@@ -49,19 +50,19 @@
         messageEnd: '</span>',
         listBtnDelete:
             '<svg class="form__icon form__icon--delete" width="18" height="18" focusable="false" aria-hidden="true">' +
-            '<use xlink:href="/_assets/d867b284b013b280ddc9dda86ad2fa21/Icons/sprite.svg#icon-delete" x="0" y="0"></use>' +
+            '<use xlink:href="' + pathIconSvg + '#icon-delete" x="0" y="0"></use>' +
             '</svg>',
         listBtnDownload:
             '<svg class="form__icon form__icon--download" width="18" height="18" focusable="false" aria-hidden="true">' +
-            '<use xlink:href="/_assets/d867b284b013b280ddc9dda86ad2fa21/Icons/sprite.svg#icon-download" x="0" y="0"></use>' +
+            '<use xlink:href="' + pathIconSvg + '#icon-download" x="0" y="0"></use>' +
             '</svg>',
         errorSVG:
             '<svg class="form__icon form__icon--error" width="18" height="18" focusable="false" aria-hidden="true">' +
-            '<use xlink:href="/_assets/d867b284b013b280ddc9dda86ad2fa21/Icons/sprite.svg#icon-error" x="0" y="0"></use>' +
+            '<use xlink:href="' + pathIconSvg + '#icon-error" x="0" y="0"></use>' +
             '</svg>',
         stagedFile:
             '<svg class="form__icon form__icon--uploaded" width="18" height="18" focusable="false" aria-hidden="true">' +
-            '<use xlink:href="/_assets/d867b284b013b280ddc9dda86ad2fa21/Icons/sprite.svg#icon-file-uploaded" x="0" y="0"></use>' +
+            '<use xlink:href="' + pathIconSvg + '#icon-file-uploaded" x="0" y="0"></use>' +
             '</svg>'
     };
 

--- a/Resources/Private/Frontend/js-source/validator.js
+++ b/Resources/Private/Frontend/js-source/validator.js
@@ -47,7 +47,8 @@
     const idRoot = 'oap-proposal-';
     const blockSubmit = true;
     const validatorSeparator = ',';
-    const errorIcon = '<svg class="form__icon form__icon--error" width="20" height="22" focusable="false" aria-hidden="true"> <use xlink:href="/_assets/d867b284b013b280ddc9dda86ad2fa21/Icons/sprite.svg#icon-error" x="0" y="0"/> </svg>';
+    const pathIconSvg = OAP.assetPath + 'Icons/sprite.svg';
+    const errorIcon = '<svg class="form__icon form__icon--error" width="20" height="22" focusable="false" aria-hidden="true"> <use xlink:href="' + pathIconSvg + '#icon-error" x="0" y="0"/> </svg>';
     let validationOnStart = false;
     let countId = 0;
     let validatableFormFields = [];

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,5 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-	<div class="tx-open-oap">
+	<div class="tx-open-oap" data-oap-asset-path="{f:uri.resource(path:'Css/styles.css',extensionName: 'open_oap')->v:format.replace(substring:'Css/styles.css',replacement:'')}">
 		<f:render section="content" />
 	</div>
 </html>


### PR DESCRIPTION
Uses a dynamic asset path for icons in the upload and validator JavaScript files. The base path is now configurable in the layout and passed to JavaScript, allowing icons to be loaded from the correct location. 